### PR TITLE
Track password retries in code to avoid erroneous lock notifications

### DIFF
--- a/features/LimitRetry.inc.php
+++ b/features/LimitRetry.inc.php
@@ -68,12 +68,15 @@ class LimitRetry {
 				// And the user is not currently locked
 				if ($user->getCount() < $this->_maxRetries || $user->getFailedTime() <= time() - $this->_lockSeconds) {
 					$badpwFailedLoginsDao->resetCount($user);
+                                        // Update the local counter
+                                        $count = 0;
 				}
 			}
 
 			// Update the count to represent this failed attempt
 			$badpwFailedLoginsDao->incCount($user);
-
+			// Update the local counter
+                        $count ++;
 			// Warn the user if the attempts have been exhausted
 			if ($count >= $this->_maxRetries) {
 				$templateManager->assign('error', 'plugins.generic.betterPassword.validation.betterPasswordLocked');


### PR DESCRIPTION
Fixes complaint in Issue #63. User can allow previously incurred block to expire, fail to login once more, while remaining below the max retry condition. User will now not receive a lockout message until they actually generate enough retries to incur another lockout. 